### PR TITLE
feat(index): turn throw 'expect called with WebElement' into console.warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,8 +215,8 @@ var originalExpect = global.expect;
 global.expect = function(actual) {
   if (actual instanceof webdriver.promise.Promise) {
     if (actual instanceof webdriver.WebElement) {
-      throw 'expect called with WebElement argument, expected a Promise. ' +
-          'Did you mean to use .getText()?';
+      console.warn('Warning: expect called with WebElement argument, ' +
+        'usually expected a Promise. Did you mean to use .getText()?');
     }
     return promiseMatchers(actual);
   } else {

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -167,13 +167,12 @@ describe('webdriverJS Jasmine adapter', function() {
     });
   });
 
-  it('should throw an error with a WebElement actual value', function() {
+  it('should just log a warning with a WebElement actual value', function() {
     var webElement = new webdriver.WebElement(fakeDriver, 'idstring');
 
     expect(function() {
-      expect(webElement).toEqual(4);
-    }).toThrow('expect called with WebElement argument, expected a Promise. ' +
-        'Did you mean to use .getText()?');
+      expect(webElement).toBeDefined();
+    }).not.toThrow();
   });
 
   // Uncomment to see timeout failures.


### PR DESCRIPTION
Throwing the error might be useful to avoid newbies problems but I'm trying to use a Jasmine 1.3.x [custom](https://gist.github.com/elgalu/94284ec0ac3e8a590507) matcher `toHaveClass` that is able to work on ElementFinders and WebElements, usage looks like:

``` js
expect(elmFinder).toHaveClass('ng-invalid');
expect(webElm).not.toHaveClass('ZZZ');
```

Only way to get it working is with this PR
