### PR TITLE
Continue tests when current callback throws exception (like element() no...

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,13 +91,18 @@ function wrapInControlFlow(globalFn, fnName) {
         }
 
         var flowFinished = flow.execute(function() {
-          fn.call(jasmine.getEnv().currentSpec, function(userError) {
-            if (userError) {
-              asyncFnDone.reject(new Error(userError));
-            } else {
-              asyncFnDone.fulfill();
-            }
-          });
+          try {
+            fn.call(jasmine.getEnv().currentSpec, function(userError) {
+              if (userError) {
+                asyncFnDone.reject(new Error(userError));
+              } else {
+                asyncFnDone.fulfill();
+              }
+            });
+          }
+          catch (ex) {
+            asyncFnDone.reject(ex);
+          }
         }, desc_);
 
         webdriver.promise.all([asyncFnDone, flowFinished]).then(function() {


### PR DESCRIPTION
Continue but mark spec as failed when current async call throws an exception due to element() not finding an item.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/jasminewd/12)

<!-- Reviewable:end -->
