### PR TITLE
feat(index): add jasmine2.0 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,39 +72,36 @@ function wrapInControlFlow(globalFn, fnName) {
     var driverError = new Error();
     driverError.stack = driverError.stack.replace(/ +at.+jasminewd.+\n/, '');
 
-    function asyncTestFn(fn, desc) {
+    function asyncTestFn(fn) {
       return function(done) {
-        var desc_ = 'Asynchronous test function: ' + fnName + '(';
-        if (desc) {
-          desc_ += '"' + desc + '"';
-        }
-        desc_ += ')';
-
         // deferred object for signaling completion of asychronous function within globalFn
-        var asyncFnDone = webdriver.promise.defer();
+        var asyncFnDone = webdriver.promise.defer(),
+          originalFail = jasmine.getEnv().fail;
 
         if (fn.length === 0) {
           // function with globalFn not asychronous
           asyncFnDone.fulfill();
         } else if (fn.length > 1) {
           throw Error('Invalid # arguments (' + fn.length + ') within function "' + fnName +'"');
+        } else {
+          // Add fail method to async done callback and override env fail to
+          // reject async done promise
+          jasmine.getEnv().fail = asyncFnDone.fulfill.fail = function(userError) {
+            asyncFnDone.reject(new Error(userError));
+          };
         }
 
         var flowFinished = flow.execute(function() {
-          fn.call(jasmine.getEnv().currentSpec, function(userError) {
-            if (userError) {
-              asyncFnDone.reject(new Error(userError));
-            } else {
-              asyncFnDone.fulfill();
-            }
-          });
-        }, desc_);
+          fn.call(jasmine.getEnv(), asyncFnDone.fulfill);
+        });
 
         webdriver.promise.all([asyncFnDone, flowFinished]).then(function() {
+          jasmine.getEnv().fail = originalFail;
           seal(done)();
         }, function(e) {
-          e.stack = e.stack + '==== async task ====\n' + driverError.stack;
-          done(e);
+          jasmine.getEnv().fail = originalFail;
+          e.stack = e.stack + '\n==== async task ====\n' + driverError.stack;
+          done.fail(e);
         });
       };
     }
@@ -112,7 +109,7 @@ function wrapInControlFlow(globalFn, fnName) {
     var description, func, timeout;
     switch (fnName) {
       case 'it':
-      case 'iit':
+      case 'fit':
         description = validateString(arguments[0]);
         func = validateFunction(arguments[1]);
         if (!arguments[2]) {
@@ -124,6 +121,8 @@ function wrapInControlFlow(globalFn, fnName) {
         break;
       case 'beforeEach':
       case 'afterEach':
+      case 'beforeAll':
+      case 'afterAll':
         func = validateFunction(arguments[0]);
         if (!arguments[1]) {
           globalFn(asyncTestFn(func));
@@ -139,116 +138,98 @@ function wrapInControlFlow(globalFn, fnName) {
 }
 
 global.it = wrapInControlFlow(global.it, 'it');
-global.iit = wrapInControlFlow(global.iit, 'iit');
+global.fit = wrapInControlFlow(global.fit, 'fit');
 global.beforeEach = wrapInControlFlow(global.beforeEach, 'beforeEach');
 global.afterEach = wrapInControlFlow(global.afterEach, 'afterEach');
-
-
-/**
- * Wrap a Jasmine matcher function so that it can take webdriverJS promises.
- * @param {!Function} matcher The matcher function to wrap.
- * @param {webdriver.promise.Promise} actualPromise The promise which will
- *     resolve to the actual value being tested.
- * @param {boolean} not Whether this is being called with 'not' active.
- */
-function wrapMatcher(matcher, actualPromise, not) {
-  return function() {
-    var originalArgs = arguments;
-    var matchError = new Error("Failed expectation");
-    matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
-    actualPromise.then(function(actual) {
-      var expected = originalArgs[0];
-
-      var expectation = originalExpect(actual);
-      if (not) {
-        expectation = expectation.not;
-      }
-      var originalAddMatcherResult = expectation.spec.addMatcherResult;
-      var error = matchError;
-      expectation.spec.addMatcherResult = function(result) {
-        result.trace = error;
-        jasmine.Spec.prototype.addMatcherResult.call(this, result);
-      };
-
-      if (webdriver.promise.isPromise(expected)) {
-        if (originalArgs.length > 1) {
-          throw error('Multi-argument matchers with promises are not ' +
-              'supported.');
-        }
-        expected.then(function(exp) {
-          expectation[matcher].apply(expectation, [exp]);
-          expectation.spec.addMatcherResult = originalAddMatcherResult;
-        });
-      } else {
-        expectation.spec.addMatcherResult = function(result) {
-          result.trace = error;
-          originalAddMatcherResult.call(this, result);
-        };
-        expectation[matcher].apply(expectation, originalArgs);
-        expectation.spec.addMatcherResult = originalAddMatcherResult;
-      }
-    });
-  };
-}
-
-/**
- * Return a chained set of matcher functions which will be evaluated
- * after actualPromise is resolved.
- * @param {webdriver.promise.Promise} actualPromise The promise which will
- *     resolve to the actual value being tested.
- */
-function promiseMatchers(actualPromise) {
-  var promises = {not: {}};
-  var env = jasmine.getEnv();
-  var matchersClass = env.currentSpec.matchersClass || env.matchersClass;
-
-  for (var matcher in matchersClass.prototype) {
-    promises[matcher] = wrapMatcher(matcher, actualPromise, false);
-    promises.not[matcher] = wrapMatcher(matcher, actualPromise, true);
-  }
-
-  return promises;
-}
+global.beforeAll = wrapInControlFlow(global.beforeAll, 'beforeAll');
+global.afterAll = wrapInControlFlow(global.afterAll, 'afterAll');
 
 var originalExpect = global.expect;
-
 global.expect = function(actual) {
   if (actual instanceof webdriver.WebElement) {
     throw 'expect called with WebElement argument, expected a Promise. ' +
         'Did you mean to use .getText()?';
   }
-  if (webdriver.promise.isPromise(actual)) {
-    return promiseMatchers(actual);
-  } else {
-    return originalExpect(actual);
-  }
+  return originalExpect(actual);
 };
 
-// Wrap internal Jasmine function to allow custom matchers
-// to return promises that resolve to truthy or falsy values
-var originalMatcherFn = jasmine.Matchers.matcherFn_;
-jasmine.Matchers.matcherFn_ = function(matcherName, matcherFunction) {
-  var matcherFnThis = this;
-  var matcherFnArgs = jasmine.util.argsToArray(arguments);
+/**
+ * Creates a matcher wrapper that resolves any promises given for actual and
+ * expected values, as well as the `pass` property of the result.
+ */
+jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
   return function() {
-    var matcherThis = this;
-    var matcherArgs = jasmine.util.argsToArray(arguments);
-    var result = matcherFunction.apply(this, arguments);
+    var expected = Array.prototype.slice.call(arguments, 0),
+      expectation = this,
+      matchError = new Error("Failed expectation");
 
-    if (webdriver.promise.isPromise(result)) {
-      result.then(function(resolution) {
-        matcherFnArgs[1] = function() {
-          return resolution;
-        };
-        originalMatcherFn.apply(matcherFnThis, matcherFnArgs).
-            apply(matcherThis, matcherArgs);
+    matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
+
+    flow.execute(function() {
+      return webdriver.promise.when(expectation.actual).then(function(actual) {
+        return webdriver.promise.all(expected).then(function(expected) {
+          return compare(actual, expected);
+        });
       });
-    } else {
-      originalMatcherFn.apply(matcherFnThis, matcherFnArgs).
-          apply(matcherThis, matcherArgs);
+    });
+
+    function compare(actual, expected) {
+      var args = expected.slice(0);
+      args.unshift(actual);
+
+      var matcher = matcherFactory(expectation.util, expectation.customEqualityTesters);
+      var matcherCompare = matcher.compare;
+
+      if (expectation.isNot) {
+        matcherCompare = matcher.negativeCompare || defaultNegativeCompare;
+      }
+
+      var result = matcherCompare.apply(null, args);
+
+      return webdriver.promise.when(result.pass).then(function(pass) {
+        var message = "";
+
+        if (!pass) {
+          if (!result.message) {
+            args.unshift(expectation.isNot);
+            args.unshift(name);
+            message = expectation.util.buildFailureMessage.apply(null, args);
+          } else {
+            message = result.message;
+          }
+        }
+
+        if (expected.length == 1) {
+          expected = expected[0];
+        }
+        var res = {
+          matcherName: name,
+          passed: pass,
+          message: message,
+          actual: actual,
+          expected: expected,
+          error: matchError
+        };
+        expectation.addExpectationResult(pass, res);
+      });
+
+      function defaultNegativeCompare() {
+        var result = matcher.compare.apply(null, args);
+        if (webdriver.promise.isPromise(result.pass)) {
+          result.pass = result.pass.then(function(pass) {
+            return !pass;
+          });
+        } else {
+          result.pass = !result.pass;
+        }
+        return result;
+      }
     }
   };
 };
+
+// Re-add core matchers so they are wrapped.
+jasmine.Expectation.addCoreMatchers(jasmine.matchers);
 
 /**
  * A Jasmine reporter which does nothing but execute the input function
@@ -258,30 +239,17 @@ var OnTimeoutReporter = function(fn) {
   this.callback = fn;
 };
 
-OnTimeoutReporter.prototype.reportRunnerStarting = function() {};
-OnTimeoutReporter.prototype.reportRunnerResults = function() {};
-OnTimeoutReporter.prototype.reportSuiteResults = function() {};
-OnTimeoutReporter.prototype.reportSpecStarting = function() {};
-OnTimeoutReporter.prototype.reportSpecResults = function(spec) {
-  if (!spec.results().passed()) {
-    var result = spec.results();
-    var failureItem = null;
+OnTimeoutReporter.prototype.specDone = function(result) {
+  if (result.status === 'failed') {
+    for (var i = 0; i < result.failedExpectations.length; i++) {
+      var failureMessage = result.failedExpectations[i].message;
 
-    var items_length = result.getItems().length;
-    for (var i = 0; i < items_length; i++) {
-      if (result.getItems()[i].passed_ === false) {
-        failureItem = result.getItems()[i];
-
-        var jasmineTimeoutRegexp =
-            /timed out after \d+ msec waiting for spec to complete/;
-        if (failureItem.toString().match(jasmineTimeoutRegexp)) {
-          this.callback();
-        }
+      if (failureMessage.match(/Timeout/)) {
+        this.callback();
       }
     }
   }
 };
-OnTimeoutReporter.prototype.log = function() {};
 
 // On timeout, the flow should be reset. This will prevent webdriver tasks
 // from overflowing into the next test and causing it to fail or timeout
@@ -292,7 +260,7 @@ jasmine.getEnv().addReporter(new OnTimeoutReporter(function() {
   console.warn('A Jasmine spec timed out. Resetting the WebDriver Control Flow.');
   console.warn('The last active task was: ');
   console.warn(
-      (flow.activeFrame_  && flow.activeFrame_.getPendingTask() ?
+      (flow.activeFrame_ && flow.activeFrame_.getPendingTask() ?
           flow.activeFrame_.getPendingTask().toString() : 
           'unknown'));
   flow.reset();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "jasminewd",
-  "description": "WebDriverJS adapter for Jasmine.",
+  "name": "jasminewd2",
+  "description": "WebDriverJS adapter for Jasmine2.",
   "homepage": "https://github.com/angular/jasminewd",
   "keywords": [
     "test",
@@ -13,7 +13,7 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "devDependencies": {
     "jshint": "2.5.0",
-    "minijasminenode": "1.1.1",
+    "jasmine": "2.1.1",
     "selenium-webdriver": "2.43.4"
   },
   "repository": {
@@ -23,8 +23,8 @@
   "main": "index.js",
   "scripts": {
     "pretest": "node_modules/.bin/jshint index.js spec",
-    "test": "node node_modules/.bin/minijasminenode spec/adapterSpec.js"
+    "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "1.1.0"
+  "version": "1.0.0"
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,19 @@
+PASSING_SPECS="spec/support/passing_specs.json"
+FAILING_SPECS="spec/support/failing_specs.json"
+CMD_BASE="node node_modules/.bin/jasmine JASMINE_CONFIG_PATH="
+
+echo "### running passing specs"
+CMD=$CMD_BASE$PASSING_SPECS
+$CMD
+[ "$?" -eq 0 ] || exit 1
+echo
+
+EXPECTED_RESULTS="13 specs, 12 failures"
+echo "### running failing specs (expecting $EXPECTED_RESULTS)" 
+CMD=$CMD_BASE$FAILING_SPECS
+res=`$CMD 2>/dev/null`
+results_line=`echo "$res" | tail -2 | head -1`
+echo "result: $results_line"
+[ "$results_line" = "$EXPECTED_RESULTS" ] || exit 1
+
+echo "all pass"

--- a/spec/common.js
+++ b/spec/common.js
@@ -1,0 +1,93 @@
+require('../index.js');
+var webdriver = require('selenium-webdriver');
+
+exports.getFakeDriver = function() {
+  var flow = webdriver.promise.controlFlow();
+  return {
+    controlFlow: function() {
+      return flow;
+    },
+    sleep: function(ms) {
+      return flow.timeout(ms);
+    },
+    setUp: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled('setup done');
+      });
+    },
+    getValueA: function() {
+      return flow.execute(function() {
+        return webdriver.promise.delayed(500).then(function() {
+          return webdriver.promise.fulfilled('a');
+        });
+      });
+    },
+    getOtherValueA: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled('a');
+      });
+    },
+    getValueB: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled('b');
+      });
+    },
+    getBigNumber: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled(1111);
+      });
+    },
+    getSmallNumber: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled(11);
+      });
+    },
+    getDecimalNumber: function() {
+        return flow.execute(function() {
+          return webdriver.promise.fulfilled(3.14159);
+        });
+      },
+    getDisplayedElement: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled({
+          isDisplayed: function() {
+            return webdriver.promise.fulfilled(true);
+          }
+        });
+      });
+    },
+    getHiddenElement: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled({
+          isDisplayed: function() {
+            return webdriver.promise.fulfilled(false);
+          }
+        });
+      });
+    }
+  };
+};
+
+exports.getMatchers = function() {
+  return {
+    toBeLotsMoreThan: function() {
+      return {
+        compare: function(actual, expected) {
+          return {
+            pass: actual > expected + 100
+          };
+        }
+      };
+    },
+    // Example custom matcher returning a promise that resolves to true/false.
+    toBeDisplayed: function() {
+      return {
+        compare: function(actual, expected) {
+          return {
+            pass: actual.isDisplayed()
+          };
+        }
+      };
+    }
+  };
+};

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -1,0 +1,90 @@
+var webdriver = require('selenium-webdriver');
+var common = require('./common.js');
+
+/**
+ * Error tests for the WebDriverJS Jasmine-Node Adapter. These tests use
+ * WebDriverJS's control flow and promises without setting up the whole
+ * webdriver.
+ */
+
+var fakeDriver = common.getFakeDriver();
+
+describe('Timeout cases', function() {
+
+  // Uncomment to see timeout failures.
+  it('should timeout after 200ms', function(done) {
+    expect(fakeDriver.getValueA()).toEqual('a');
+  }, 200);
+  
+  it('should timeout after 300ms', function() {
+    fakeDriver.sleep(9999);
+    expect(fakeDriver.getValueB()).toEqual('b');
+  }, 300);
+
+  it('should pass after the timed out tests', function() {
+    expect(true).toEqual(true);
+  });
+});
+
+describe('things that should fail', function() {
+  beforeEach(function() {
+    jasmine.addMatchers(common.getMatchers());
+  });
+
+  it('should pass errors from done callback', function(done) {
+    done.fail('an error');
+  });
+
+  it('should fail normal synchronous tests', function() {
+    expect(true).toBe(false);
+  });
+
+  it('should compare a promise to a primitive', function() {
+    expect(fakeDriver.getValueA()).toEqual('d');
+    expect(fakeDriver.getValueB()).toEqual('e');
+  });
+
+  it('should wait till the expect to run the flow', function() {
+    var promiseA = fakeDriver.getValueA();
+    expect(promiseA.isPending()).toBe(true);
+    expect(promiseA).toEqual('a');
+    expect(promiseA.isPending()).toBe(false);
+  });
+
+  it('should compare a promise to a promise', function() {
+    expect(fakeDriver.getValueA()).toEqual(fakeDriver.getValueB());
+  });
+
+  it('should still allow use of the underlying promise', function() {
+    var promiseA = fakeDriver.getValueA();
+    promiseA.then(function(value) {
+      expect(value).toEqual('b');
+    });
+  });
+
+  it('should allow scheduling of tasks', function() {
+    fakeDriver.sleep(300);
+    expect(fakeDriver.getValueB()).toEqual('c');
+  });
+
+  it('should allow the use of custom matchers', function() {
+    expect(1000).toBeLotsMoreThan(999);
+    expect(fakeDriver.getBigNumber()).toBeLotsMoreThan(1110);
+    expect(fakeDriver.getBigNumber()).not.toBeLotsMoreThan(fakeDriver.getSmallNumber());
+    expect(fakeDriver.getSmallNumber()).toBeLotsMoreThan(fakeDriver.getBigNumber());
+  });
+
+  it('should allow custom matchers to return a promise', function() {
+    expect(fakeDriver.getDisplayedElement()).not.toBeDisplayed();
+    expect(fakeDriver.getHiddenElement()).toBeDisplayed();
+  });
+
+  it('should pass multiple arguments to matcher', function() {
+    // Passing specific precision
+    expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.5, 1);
+
+    // Using default precision (2)
+    expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.1);
+    expect(fakeDriver.getDecimalNumber()).not.toBeCloseTo(3.14);
+  });
+});

--- a/spec/support/failing_specs.json
+++ b/spec/support/failing_specs.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "errorSpec.js"
+  ]
+}

--- a/spec/support/passing_specs.json
+++ b/spec/support/passing_specs.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "adapterSpec.js"
+  ]
+}


### PR DESCRIPTION
Based partly from @xdissent's https://github.com/xdissent/jasminewd/commit/9918728f73e20f21bbff13479363159f22129af3

This jasminewd is compatible with jasmine2.0 only. 

Starting this version, Protractor will stop using minijasminenode at https://github.com/juliemr/minijasminenode. Instead, it will use the official jasmine-node module at https://github.com/jasmine/jasmine-npm
