### PR TITLE
#22 Pass actual test context to test callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ function wrapInControlFlow(globalFn, fnName) {
     function asyncTestFn(fn) {
       return function(done) {
         // deferred object for signaling completion of asychronous function within globalFn
-        var asyncFnDone = webdriver.promise.defer();
+        var asyncFnDone = webdriver.promise.defer(),
+          testContext = this;
 
         if (fn.length === 0) {
           // function with globalFn not asychronous
@@ -92,7 +93,7 @@ function wrapInControlFlow(globalFn, fnName) {
         }
 
         var flowFinished = flow.execute(function() {
-          fn.call(jasmine.getEnv(), asyncFnDone.fulfill);
+          fn.call(testContext, asyncFnDone.fulfill);
         }, 'Run ' + fnName + ' in control flow');
 
         webdriver.promise.all([asyncFnDone, flowFinished]).then(function() {

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -134,4 +134,31 @@ describe('webdriverJS Jasmine adapter', function() {
       }, 500);
     });
   });
+
+  describe("should pass actual context to test methods", function(){
+    var count = 0,
+      firstContextValue;
+
+    beforeEach(function(){
+      expect(this).toEqual({});
+    });
+
+    beforeEach(function(){
+      this.contextValue = count++;
+    });
+
+    afterEach(function(){
+      expect(this.contextValue).toBeDefined();
+    });
+
+    it('should generate a unique context', function(){
+      firstContextValue = this.contextValue;
+      expect(this.contextValue).toBeDefined();
+    });
+
+    it('should generate a different context', function(){
+      expect(firstContextValue).not.toEqual(this.contextValue);
+      expect(this.contextValue).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
Manually tested, and jasmine context is correctly passed to test functions.

Fixes #22 