### PR TITLE
refactor(asyncTestFn): refactor async test wrapping to show more info

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,7 +8,7 @@ $CMD
 [ "$?" -eq 0 ] || exit 1
 echo
 
-EXPECTED_RESULTS="13 specs, 12 failures"
+EXPECTED_RESULTS="14 specs, 13 failures"
 echo "### running failing specs (expecting $EXPECTED_RESULTS)" 
 CMD=$CMD_BASE$FAILING_SPECS
 res=`$CMD 2>/dev/null`

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -16,6 +16,21 @@ describe('webdriverJS Jasmine adapter plain', function() {
   });
 });
 
+describe('context', function() {
+  beforeEach(function() {
+    this.foo = 0;
+  });
+
+  it('can use the `this` to share state', function() {
+    expect(this.foo).toEqual(0);
+    this.bar = 'test pollution?';
+  });
+
+  it('prevents test pollution by having an empty `this` created for the next spec', function() {
+    expect(this.foo).toEqual(0);
+    expect(this.bar).toBe(undefined);
+  });
+});
 
 describe('webdriverJS Jasmine adapter', function() {
   // Shorten this and you should see tests timing out.

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -38,6 +38,10 @@ describe('things that should fail', function() {
     expect(true).toBe(false);
   });
 
+  it('should fail when an error is thrown', function() {
+    throw new Error('I am an intentional error');
+  });
+
   it('should compare a promise to a primitive', function() {
     expect(fakeDriver.getValueA()).toEqual('d');
     expect(fakeDriver.getValueB()).toEqual('e');


### PR DESCRIPTION
Test wrapping for Jasmine 2 now more closely follows the test wrapping
for Mocha at https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/testing/index.js

This also adds more information to the task names in the control flow,
for easier debugging.