### PR TITLE
chore(selenium-webdriver): update selenium webdriver to 2.47.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,13 +162,11 @@ jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
 
     matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
 
-    flow.execute(function() {
-      return webdriver.promise.when(expectation.actual).then(function(actual) {
-        return webdriver.promise.all(expected).then(function(expected) {
-          return compare(actual, expected);
-        });
+    webdriver.promise.when(expectation.actual).then(function(actual) {
+      return webdriver.promise.all(expected).then(function(expected) {
+        return compare(actual, expected);
       });
-    }, 'Expect ' + name);
+    });
 
     function compare(actual, expected) {
       var args = expected.slice(0);

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "devDependencies": {
     "jshint": "2.5.0",
-    "jasmine": "2.3.1",
-    "selenium-webdriver": "2.45.1"
+    "jasmine": "2.3.2",
+    "selenium-webdriver": "2.47.0"
   },
   "repository": {
     "type": "git",

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -109,6 +109,34 @@ describe('webdriverJS Jasmine adapter', function() {
       expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.14);
     });
 
+  it('should allow iterating through arrays', function() {
+    // This is a convoluted test which shows a real issue which
+    // cropped up in version changes to the selenium-webdriver module.
+    // See https://github.com/angular/protractor/pull/2263
+    var checkTexts = function(webElems) {
+      var texts = webElems.then(function(arr) {
+        var results = arr.map(function(webElem) {
+          return webElem.getText();
+        });
+        return webdriver.promise.all(results);
+      });
+
+      expect(texts).not.toContain('e');
+
+      return true;
+    };
+
+    fakeDriver.getValueList().then(function(list) {
+      var result = list.map(function(webElem) {
+        var webElemsPromise = webdriver.promise.fulfilled(webElem).then(function(webElem) {
+          return [webElem];
+        });
+        return webdriver.promise.fullyResolved(checkTexts(webElemsPromise));
+      });
+      return webdriver.promise.all(result);
+    });
+  });
+
   describe('not', function() {
     it('should still pass normal synchronous tests', function() {
       expect(4).not.toEqual(5);

--- a/spec/common.js
+++ b/spec/common.js
@@ -64,6 +64,27 @@ exports.getFakeDriver = function() {
           }
         });
       }, 'getHiddenElement');
+    },
+    getValueList: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled([{
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('a');});
+          }
+        }, {
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('b');});
+          }
+        }, {
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('c');});
+          }
+        }, {
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('d');});
+          }
+        }]);
+      }, 'getValueList');
     }
   };
 };


### PR DESCRIPTION
Update selenium-webdriver to 2.47.0 from 2.45.1.
This update introduces a convoluted situation where some tests in
Proractor's suite would hang - see https://github.com/angular/protractor/issues/2245

This change includes a fix for those issues which removes the explicit
`flow.execute` wrapper around `expect` calls. This appears not to introduce
any issues to existing tests.