### PR TITLE
Pin the selenium-webdriver version so that it correctly matches protractor.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 node_modules/
 spec/
+scripts/
 .travis.yml
 .npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
   - "4"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
+  - "4"
 
 script:
   - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,39 @@
-# 1.1.0
+# Changelog for jasminewd2
 
-## Dependency Updates
-- ([daa67d6])(https://github.com/angular/jasminewd/commit/daa67d6eabdd9c70306748da8a0dc0a6f2edb90f)) chore(dependencies): update to selenium-webdriver 2.43.4
+# 0.0.5
 
-# 1.0.4
-## Bug Fixes
-- ([a088e6f](https://github.com/angular/jasminewd/commit/a088e6f175ca817f59d5eea99549e45ab5861ce0)) fix(timeouts): should call special timeout handlers only for a jasmine timeout
+- ([037c7de](https://github.com/angular/jasminewd/commit/037c7de7fea4de068734b6fa250d145800863633))
+  chore(dependencies): update Jasmine to 2.3.1
 
-    Previously, it used to call the resets if anything matched 'timeout'. This was too
-    vague, since many error messages contain that string.
+# 0.0.4
 
-    Closes #8
+- ([8f8b8b3](https://github.com/angular/jasminewd/commit/8f8b8b39e779559fd3b29b138d7577658b8a64b7))
+  tests(context): test that the `this` variable points to the right thing
 
-# 1.0.3
-## Bug Fixes
-- ([00821b3](https://github.com/angular/jasminewd/commit/00821b3180a6674012fdccab106835f5ce94bb3f)) fix(timeout): better messaging if the control flow does not have a listed last task
+  Note: this means that using `this.addMatchers` no longer works inside before blocks or specs. It
+  should have been changed to `jamsine.addMatchers` since the upgrade to Jasmine 2. It was still
+  working by accident up until the previous commit.
 
-# 1.0.2
+- ([c0f13d2](https://github.com/angular/jasminewd/commit/c0f13d254966c859db22d020a5390138dbf48e64))
+  refactor(asyncTestFn): refactor async test wrapping to show more info
 
-## Bug Fixes
-- ([30b6811](https://github.com/angular/jasminewd/commit/30b68113759a7cb5c8dabc5b16ffcd89516882d8)) fix(timeout): output more information about the current task when a timeout occurs
+  Test wrapping for Jasmine 2 now more closely follows the test wrapping for Mocha at
+  https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/testing/index.js
 
-# 1.0.1
+  This also adds more information to the task names in the control flow, for easier debugging.
 
-## Bug Fixes
-- ([c507b37](https://github.com/angular/jasminewd/commit/c507b37dd04cf267a437a579fc3b14063abb2ef8))
-  fix(index): stop infinite promise resolution
+# 0.0.3
 
-1.0.0
-=====
+- ([161e1fa](https://github.com/angular/jasminewd/commit/161e1fa48deaa5ea0f485027ea8ae41562864936))
+  fix(errors): update webdriverjs, fix asynchronous error output
 
-Support for Jasmine 1.3.1. Tested against minijasminenode @ 0.4.0.
+  Add some console logging, remove useless info about the last running task in the control flow, and
+  fix error where problems reported from done.fail were getting pushed into the following spec.
 
-Features
+  Closes #18
 
- - Automatically makes tests asynchronously wait until the WebDriverJS control flow is empty.
+- ([fdb03a3](https://github.com/angular/jasminewd/commit/fdb03a388d4846952c09fb0ad75a37b46674c750))
+  docs(readme): add note about jasmine 1 vs jasmine 2
 
- - If a `done` function is passed to the test, waits for both the control flow and until done is called.
-
- - Enhances `expect` so that it automatically unwraps promises before performing the assertion.
-
+- ([acaec8b](https://github.com/angular/jasminewd/commit/acaec8bdd157e9933d608c66204a52335fb46ee4))
+  feat(index): add jasmine2.0 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog for jasminewd2
 
+# 0.0.6
+
+- ([4776c16](https://github.com/angular/jasminewd/commit/4776c16b9a9f3a9a3de8a8dddc0e051cb32331b4))
+  chore(selenium-webdriver): update selenium webdriver to 2.47.0
+
+  Update selenium-webdriver to 2.47.0 from 2.45.1. This update introduces a convoluted situation
+  where some tests in Proractor's suite would hang - see
+  https://github.com/angular/protractor/issues/2245
+
+  This change includes a fix for those issues which removes the explicit
+  `flow.execute` wrapper around `expect` calls. This appears not to introduce any issues to existing
+  tests.
+
 # 0.0.5
 
 - ([037c7de](https://github.com/angular/jasminewd/commit/037c7de7fea4de068734b6fa250d145800863633))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for jasminewd2
 
+# 0.0.7
+
+- ([55fd11e](https://github.com/angular/protractor/commit/55fd11e69c2f1ba8fba9a19a8acccbe933896084))
+  fix(index): forward it's return value
+
+- ([f4c30a0](https://github.com/angular/protractor/commit/f4c30a0023c6ec33b15df762226c3fe8e741d26e))
+  fix: allow empty it functions
+
 # 0.0.6
 
 - ([4776c16](https://github.com/angular/jasminewd/commit/4776c16b9a9f3a9a3de8a8dddc0e051cb32331b4))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog for jasminewd2
 
+# 0.0.8
+
+- ([5abc745](https://github.com/angular/protractor/commit/5abc7457cd73a4a4ba70b3c9ceeadac6d42bbd76))
+  chore(jasmine): update MatchFactory to allow message as function
+
+- ([750898c](https://github.com/angular/protractor/commit/750898c90a1cc1bef09384b60ef6e15adfe734f7))
+  fix(expectation): expectations without promises no longer add to task queue
+
+  Instead, expectations without promises in either expected or actual are unchanged from the
+  original Jasmine implementation.
+
+  See https://github.com/angular/protractor/issues/2894
+
 # 0.0.7
 
 - ([55fd11e](https://github.com/angular/protractor/commit/55fd11e69c2f1ba8fba9a19a8acccbe933896084))

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ jasminewd [![Build Status](https://travis-ci.org/angular/jasminewd.png?branch=ma
 
 Adapter for Jasmine-to-WebDriverJS. Used by [Protractor](http://www.github.com/angular/protractor).
 
+**Important:** There are two active branches of jasminewd.
+
+ - [master](https://github.com/angular/jasminewd/tree/master) is an adapter for Jasmine 1.3, and uses the package minijasminenode. It is published to npm as `jasminewd`.
+ - [jasminewd2](https://github.com/angular/jasminewd/tree/jasminewd2) is an adapter for Jasmine 2.x, and uses the package jasmine. It is published to npm as `jasminewd2`.
 
 Features
 --------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 Installation
 ------------
 ```
-npm install jasminewd
+npm install jasminewd2
 ```
 
 Usage
@@ -26,15 +26,17 @@ Assumes selenium-webdriver as a peer dependency.
 
 ```js
 // In your setup.
-var minijn = require('minijasminenode');
-require('jasminewd');
+var JasmineRunner = require('jasmine');
+var jrunner = new JasmineRunner();
+require('jasminewd2');
 
 global.driver = new webdriver.Builder().
     usingServer('http://localhost:4444/wd/hub').
     withCapabilities({browserName: 'chrome'}).
     build();
 
-minijn.executeSpecs(/* ... */);
+jrunner.projectBaseDir = '';
+jrunner.execute(['**/*_spec.js']);
 
 // In your tests
 

--- a/index.js
+++ b/index.js
@@ -162,13 +162,11 @@ jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
 
     matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
 
-    flow.execute(function() {
-      return webdriver.promise.when(expectation.actual).then(function(actual) {
-        return webdriver.promise.all(expected).then(function(expected) {
-          return compare(actual, expected);
-        });
+    webdriver.promise.when(expectation.actual).then(function(actual) {
+      return webdriver.promise.all(expected).then(function(expected) {
+        return compare(actual, expected);
       });
-    }, 'Expect ' + name);
+    });
 
     function compare(actual, expected) {
       var args = expected.slice(0);

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
       var result = matcherCompare.apply(null, args);
 
       return webdriver.promise.when(result.pass).then(function(pass) {
-        var message = "";
+        var message = '';
 
         if (!pass) {
           if (!result.message) {
@@ -200,7 +200,11 @@ jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
             args.unshift(name);
             message = expectation.util.buildFailureMessage.apply(null, args);
           } else {
-            message = result.message;
+            if (Object.prototype.toString.apply(result.message) === '[object Function]') {
+              message = result.message();
+            } else {
+              message = result.message;
+            }
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ function wrapInControlFlow(globalFn, fnName) {
               // ignored.
               var proxyDone = fulfill;
               proxyDone.fail = function(err) {
-                reject(err);
+                var wrappedErr = new Error(err);
+                reject(wrappedErr);
               };
               testFn(proxyDone);
             } else {
@@ -96,7 +97,7 @@ function wrapInControlFlow(globalFn, fnName) {
             }
           }, flow);
         }, 'Run ' + fnName + description + ' in control flow').then(seal(done), function(err) {
-          err.stack = err.stack + '\n==== async task ====\n' + driverError.stack;
+          err.stack = err.stack + '\nFrom asynchronous test: \n' + driverError.stack;
           done.fail(err);
         });
       };

--- a/index.js
+++ b/index.js
@@ -109,15 +109,14 @@ function wrapInControlFlow(globalFn, fnName) {
       case 'fit':
         description = validateString(arguments[0]);
         if (!arguments[1]) {
-          globalFn(description);
-          break;
+          return globalFn(description);
         }
         func = validateFunction(arguments[1]);
         if (!arguments[2]) {
-          globalFn(description, asyncTestFn(func, description));
+          return globalFn(description, asyncTestFn(func, description));
         } else {
           timeout = validateNumber(arguments[2]);
-          globalFn(description, asyncTestFn(func, description), timeout);
+          return globalFn(description, asyncTestFn(func, description), timeout);
         }
         break;
       case 'beforeEach':

--- a/index.js
+++ b/index.js
@@ -72,39 +72,36 @@ function wrapInControlFlow(globalFn, fnName) {
     var driverError = new Error();
     driverError.stack = driverError.stack.replace(/ +at.+jasminewd.+\n/, '');
 
-    function asyncTestFn(fn, desc) {
+    function asyncTestFn(fn) {
       return function(done) {
-        var desc_ = 'Asynchronous test function: ' + fnName + '(';
-        if (desc) {
-          desc_ += '"' + desc + '"';
-        }
-        desc_ += ')';
-
         // deferred object for signaling completion of asychronous function within globalFn
-        var asyncFnDone = webdriver.promise.defer();
+        var asyncFnDone = webdriver.promise.defer(),
+          originalFail = jasmine.getEnv().fail;
 
         if (fn.length === 0) {
           // function with globalFn not asychronous
           asyncFnDone.fulfill();
         } else if (fn.length > 1) {
           throw Error('Invalid # arguments (' + fn.length + ') within function "' + fnName +'"');
+        } else {
+          // Add fail method to async done callback and override env fail to
+          // reject async done promise
+          jasmine.getEnv().fail = asyncFnDone.fulfill.fail = function(userError) {
+            asyncFnDone.reject(new Error(userError));
+          };
         }
 
         var flowFinished = flow.execute(function() {
-          fn.call(jasmine.getEnv().currentSpec, function(userError) {
-            if (userError) {
-              asyncFnDone.reject(new Error(userError));
-            } else {
-              asyncFnDone.fulfill();
-            }
-          });
-        }, desc_);
+          fn.call(jasmine.getEnv(), asyncFnDone.fulfill);
+        });
 
         webdriver.promise.all([asyncFnDone, flowFinished]).then(function() {
+          jasmine.getEnv().fail = originalFail;
           seal(done)();
         }, function(e) {
-          e.stack = e.stack + '==== async task ====\n' + driverError.stack;
-          done(e);
+          jasmine.getEnv().fail = originalFail;
+          e.stack = e.stack + '\n==== async task ====\n' + driverError.stack;
+          done.fail(e);
         });
       };
     }
@@ -112,7 +109,7 @@ function wrapInControlFlow(globalFn, fnName) {
     var description, func, timeout;
     switch (fnName) {
       case 'it':
-      case 'iit':
+      case 'fit':
         description = validateString(arguments[0]);
         func = validateFunction(arguments[1]);
         if (!arguments[2]) {
@@ -124,6 +121,8 @@ function wrapInControlFlow(globalFn, fnName) {
         break;
       case 'beforeEach':
       case 'afterEach':
+      case 'beforeAll':
+      case 'afterAll':
         func = validateFunction(arguments[0]);
         if (!arguments[1]) {
           globalFn(asyncTestFn(func));
@@ -139,116 +138,98 @@ function wrapInControlFlow(globalFn, fnName) {
 }
 
 global.it = wrapInControlFlow(global.it, 'it');
-global.iit = wrapInControlFlow(global.iit, 'iit');
+global.fit = wrapInControlFlow(global.fit, 'fit');
 global.beforeEach = wrapInControlFlow(global.beforeEach, 'beforeEach');
 global.afterEach = wrapInControlFlow(global.afterEach, 'afterEach');
-
-
-/**
- * Wrap a Jasmine matcher function so that it can take webdriverJS promises.
- * @param {!Function} matcher The matcher function to wrap.
- * @param {webdriver.promise.Promise} actualPromise The promise which will
- *     resolve to the actual value being tested.
- * @param {boolean} not Whether this is being called with 'not' active.
- */
-function wrapMatcher(matcher, actualPromise, not) {
-  return function() {
-    var originalArgs = arguments;
-    var matchError = new Error("Failed expectation");
-    matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
-    actualPromise.then(function(actual) {
-      var expected = originalArgs[0];
-
-      var expectation = originalExpect(actual);
-      if (not) {
-        expectation = expectation.not;
-      }
-      var originalAddMatcherResult = expectation.spec.addMatcherResult;
-      var error = matchError;
-      expectation.spec.addMatcherResult = function(result) {
-        result.trace = error;
-        jasmine.Spec.prototype.addMatcherResult.call(this, result);
-      };
-
-      if (webdriver.promise.isPromise(expected)) {
-        if (originalArgs.length > 1) {
-          throw error('Multi-argument matchers with promises are not ' +
-              'supported.');
-        }
-        expected.then(function(exp) {
-          expectation[matcher].apply(expectation, [exp]);
-          expectation.spec.addMatcherResult = originalAddMatcherResult;
-        });
-      } else {
-        expectation.spec.addMatcherResult = function(result) {
-          result.trace = error;
-          originalAddMatcherResult.call(this, result);
-        };
-        expectation[matcher].apply(expectation, originalArgs);
-        expectation.spec.addMatcherResult = originalAddMatcherResult;
-      }
-    });
-  };
-}
-
-/**
- * Return a chained set of matcher functions which will be evaluated
- * after actualPromise is resolved.
- * @param {webdriver.promise.Promise} actualPromise The promise which will
- *     resolve to the actual value being tested.
- */
-function promiseMatchers(actualPromise) {
-  var promises = {not: {}};
-  var env = jasmine.getEnv();
-  var matchersClass = env.currentSpec.matchersClass || env.matchersClass;
-
-  for (var matcher in matchersClass.prototype) {
-    promises[matcher] = wrapMatcher(matcher, actualPromise, false);
-    promises.not[matcher] = wrapMatcher(matcher, actualPromise, true);
-  }
-
-  return promises;
-}
+global.beforeAll = wrapInControlFlow(global.beforeAll, 'beforeAll');
+global.afterAll = wrapInControlFlow(global.afterAll, 'afterAll');
 
 var originalExpect = global.expect;
-
 global.expect = function(actual) {
   if (actual instanceof webdriver.WebElement) {
     throw 'expect called with WebElement argument, expected a Promise. ' +
         'Did you mean to use .getText()?';
   }
-  if (webdriver.promise.isPromise(actual)) {
-    return promiseMatchers(actual);
-  } else {
-    return originalExpect(actual);
-  }
+  return originalExpect(actual);
 };
 
-// Wrap internal Jasmine function to allow custom matchers
-// to return promises that resolve to truthy or falsy values
-var originalMatcherFn = jasmine.Matchers.matcherFn_;
-jasmine.Matchers.matcherFn_ = function(matcherName, matcherFunction) {
-  var matcherFnThis = this;
-  var matcherFnArgs = jasmine.util.argsToArray(arguments);
+/**
+ * Creates a matcher wrapper that resolves any promises given for actual and
+ * expected values, as well as the `pass` property of the result.
+ */
+jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
   return function() {
-    var matcherThis = this;
-    var matcherArgs = jasmine.util.argsToArray(arguments);
-    var result = matcherFunction.apply(this, arguments);
+    var expected = Array.prototype.slice.call(arguments, 0),
+      expectation = this,
+      matchError = new Error("Failed expectation");
 
-    if (webdriver.promise.isPromise(result)) {
-      result.then(function(resolution) {
-        matcherFnArgs[1] = function() {
-          return resolution;
-        };
-        originalMatcherFn.apply(matcherFnThis, matcherFnArgs).
-            apply(matcherThis, matcherArgs);
+    matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
+
+    flow.execute(function() {
+      return webdriver.promise.when(expectation.actual).then(function(actual) {
+        return webdriver.promise.all(expected).then(function(expected) {
+          return compare(actual, expected);
+        });
       });
-    } else {
-      originalMatcherFn.apply(matcherFnThis, matcherFnArgs).
-          apply(matcherThis, matcherArgs);
+    });
+
+    function compare(actual, expected) {
+      var args = expected.slice(0);
+      args.unshift(actual);
+
+      var matcher = matcherFactory(expectation.util, expectation.customEqualityTesters);
+      var matcherCompare = matcher.compare;
+
+      if (expectation.isNot) {
+        matcherCompare = matcher.negativeCompare || defaultNegativeCompare;
+      }
+
+      var result = matcherCompare.apply(null, args);
+
+      return webdriver.promise.when(result.pass).then(function(pass) {
+        var message = "";
+
+        if (!pass) {
+          if (!result.message) {
+            args.unshift(expectation.isNot);
+            args.unshift(name);
+            message = expectation.util.buildFailureMessage.apply(null, args);
+          } else {
+            message = result.message;
+          }
+        }
+
+        if (expected.length == 1) {
+          expected = expected[0];
+        }
+        var res = {
+          matcherName: name,
+          passed: pass,
+          message: message,
+          actual: actual,
+          expected: expected,
+          error: matchError
+        };
+        expectation.addExpectationResult(pass, res);
+      });
+
+      function defaultNegativeCompare() {
+        var result = matcher.compare.apply(null, args);
+        if (webdriver.promise.isPromise(result.pass)) {
+          result.pass = result.pass.then(function(pass) {
+            return !pass;
+          });
+        } else {
+          result.pass = !result.pass;
+        }
+        return result;
+      }
     }
   };
 };
+
+// Re-add core matchers so they are wrapped.
+jasmine.Expectation.addCoreMatchers(jasmine.matchers);
 
 /**
  * A Jasmine reporter which does nothing but execute the input function
@@ -258,30 +239,17 @@ var OnTimeoutReporter = function(fn) {
   this.callback = fn;
 };
 
-OnTimeoutReporter.prototype.reportRunnerStarting = function() {};
-OnTimeoutReporter.prototype.reportRunnerResults = function() {};
-OnTimeoutReporter.prototype.reportSuiteResults = function() {};
-OnTimeoutReporter.prototype.reportSpecStarting = function() {};
-OnTimeoutReporter.prototype.reportSpecResults = function(spec) {
-  if (!spec.results().passed()) {
-    var result = spec.results();
-    var failureItem = null;
+OnTimeoutReporter.prototype.specDone = function(result) {
+  if (result.status === 'failed') {
+    for (var i = 0; i < result.failedExpectations.length; i++) {
+      var failureMessage = result.failedExpectations[i].message;
 
-    var items_length = result.getItems().length;
-    for (var i = 0; i < items_length; i++) {
-      if (result.getItems()[i].passed_ === false) {
-        failureItem = result.getItems()[i];
-
-        var jasmineTimeoutRegexp =
-            /timed out after \d+ msec waiting for spec to complete/;
-        if (failureItem.toString().match(jasmineTimeoutRegexp)) {
-          this.callback();
-        }
+      if (failureMessage.match(/Timeout/)) {
+        this.callback();
       }
     }
   }
 };
-OnTimeoutReporter.prototype.log = function() {};
 
 // On timeout, the flow should be reset. This will prevent webdriver tasks
 // from overflowing into the next test and causing it to fail or timeout
@@ -292,7 +260,7 @@ jasmine.getEnv().addReporter(new OnTimeoutReporter(function() {
   console.warn('A Jasmine spec timed out. Resetting the WebDriver Control Flow.');
   console.warn('The last active task was: ');
   console.warn(
-      (flow.activeFrame_  && flow.activeFrame_.getPendingTask() ?
+      (flow.activeFrame_ && flow.activeFrame_.getPendingTask() ?
           flow.activeFrame_.getPendingTask().toString() : 
           'unknown'));
   flow.reset();

--- a/index.js
+++ b/index.js
@@ -108,6 +108,10 @@ function wrapInControlFlow(globalFn, fnName) {
       case 'it':
       case 'fit':
         description = validateString(arguments[0]);
+        if (!arguments[1]) {
+          globalFn(description);
+          break;
+        }
         func = validateFunction(arguments[1]);
         if (!arguments[2]) {
           globalFn(description, asyncTestFn(func, description));

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "devDependencies": {
     "jshint": "2.5.0",
-    "jasmine": "2.3.1",
-    "selenium-webdriver": "2.45.1"
+    "jasmine": "2.3.2",
+    "selenium-webdriver": "2.47.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "jasmine"
   ],
   "author": "Julie Ralph <ju.ralph@gmail.com>",
+  "dependencies": {
+    "selenium-webdriver": "2.48.2"
+  },
   "devDependencies": {
     "jshint": "2.5.0",
-    "jasmine": "2.4.1",
-    "selenium-webdriver": "2.48.2"
+    "jasmine": "2.4.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "0.0.6"
+  "version": "0.0.7"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "devDependencies": {
     "jshint": "2.5.0",
-    "jasmine": "2.1.1",
+    "jasmine": "2.3.1",
     "selenium-webdriver": "2.45.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "devDependencies": {
     "jshint": "2.5.0",
-    "jasmine": "2.3.2",
-    "selenium-webdriver": "2.47.0"
+    "jasmine": "2.4.1",
+    "selenium-webdriver": "2.48.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "0.0.7"
+  "version": "0.0.8"
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "jshint": "2.5.0",
     "jasmine": "2.1.1",
-    "selenium-webdriver": "2.43.4"
+    "selenium-webdriver": "2.45.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "jasminewd",
-  "description": "WebDriverJS adapter for Jasmine.",
+  "name": "jasminewd2",
+  "description": "WebDriverJS adapter for Jasmine2.",
   "homepage": "https://github.com/angular/jasminewd",
   "keywords": [
     "test",
@@ -13,7 +13,7 @@
   "author": "Julie Ralph <ju.ralph@gmail.com>",
   "devDependencies": {
     "jshint": "2.5.0",
-    "minijasminenode": "1.1.1",
+    "jasmine": "2.1.1",
     "selenium-webdriver": "2.43.4"
   },
   "repository": {
@@ -23,8 +23,8 @@
   "main": "index.js",
   "scripts": {
     "pretest": "node_modules/.bin/jshint index.js spec",
-    "test": "node node_modules/.bin/minijasminenode spec/adapterSpec.js"
+    "test": "scripts/test.sh"
   },
   "license": "MIT",
-  "version": "1.1.0"
+  "version": "0.0.2"
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,19 @@
+PASSING_SPECS="spec/support/passing_specs.json"
+FAILING_SPECS="spec/support/failing_specs.json"
+CMD_BASE="node node_modules/.bin/jasmine JASMINE_CONFIG_PATH="
+
+echo "### running passing specs"
+CMD=$CMD_BASE$PASSING_SPECS
+$CMD
+[ "$?" -eq 0 ] || exit 1
+echo
+
+EXPECTED_RESULTS="13 specs, 12 failures"
+echo "### running failing specs (expecting $EXPECTED_RESULTS)" 
+CMD=$CMD_BASE$FAILING_SPECS
+res=`$CMD 2>/dev/null`
+results_line=`echo "$res" | tail -2 | head -1`
+echo "result: $results_line"
+[ "$results_line" = "$EXPECTED_RESULTS" ] || exit 1
+
+echo "all pass"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,7 @@ CMD_BASE="node node_modules/.bin/jasmine JASMINE_CONFIG_PATH="
 
 echo "### running passing specs"
 CMD=$CMD_BASE$PASSING_SPECS
+echo "### $CMD"
 $CMD
 [ "$?" -eq 0 ] || exit 1
 echo
@@ -11,6 +12,7 @@ echo
 EXPECTED_RESULTS="14 specs, 13 failures"
 echo "### running failing specs (expecting $EXPECTED_RESULTS)"
 CMD=$CMD_BASE$FAILING_SPECS
+echo "### $CMD"
 res=`$CMD 2>/dev/null`
 results_line=`echo "$res" | tail -2 | head -1`
 echo "result: $results_line"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ $CMD
 echo
 
 EXPECTED_RESULTS="14 specs, 13 failures"
-echo "### running failing specs (expecting $EXPECTED_RESULTS)" 
+echo "### running failing specs (expecting $EXPECTED_RESULTS)"
 CMD=$CMD_BASE$FAILING_SPECS
 res=`$CMD 2>/dev/null`
 results_line=`echo "$res" | tail -2 | head -1`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,7 +8,7 @@ $CMD
 [ "$?" -eq 0 ] || exit 1
 echo
 
-EXPECTED_RESULTS="13 specs, 12 failures"
+EXPECTED_RESULTS="14 specs, 13 failures"
 echo "### running failing specs (expecting $EXPECTED_RESULTS)" 
 CMD=$CMD_BASE$FAILING_SPECS
 res=`$CMD 2>/dev/null`

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ $CMD
 [ "$?" -eq 0 ] || exit 1
 echo
 
-EXPECTED_RESULTS="15 specs, 14 failures"
+EXPECTED_RESULTS="16 specs, 15 failures"
 echo "### running failing specs (expecting $EXPECTED_RESULTS)"
 CMD=$CMD_BASE$FAILING_SPECS
 echo "### $CMD"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ $CMD
 [ "$?" -eq 0 ] || exit 1
 echo
 
-EXPECTED_RESULTS="14 specs, 13 failures"
+EXPECTED_RESULTS="15 specs, 14 failures"
 echo "### running failing specs (expecting $EXPECTED_RESULTS)"
 CMD=$CMD_BASE$FAILING_SPECS
 echo "### $CMD"

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -109,6 +109,34 @@ describe('webdriverJS Jasmine adapter', function() {
       expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.14);
     });
 
+  it('should allow iterating through arrays', function() {
+    // This is a convoluted test which shows a real issue which
+    // cropped up in version changes to the selenium-webdriver module.
+    // See https://github.com/angular/protractor/pull/2263
+    var checkTexts = function(webElems) {
+      var texts = webElems.then(function(arr) {
+        var results = arr.map(function(webElem) {
+          return webElem.getText();
+        });
+        return webdriver.promise.all(results);
+      });
+
+      expect(texts).not.toContain('e');
+
+      return true;
+    };
+
+    fakeDriver.getValueList().then(function(list) {
+      var result = list.map(function(webElem) {
+        var webElemsPromise = webdriver.promise.fulfilled(webElem).then(function(webElem) {
+          return [webElem];
+        });
+        return webdriver.promise.fullyResolved(checkTexts(webElemsPromise));
+      });
+      return webdriver.promise.all(result);
+    });
+  });
+
   describe('not', function() {
     it('should still pass normal synchronous tests', function() {
       expect(4).not.toEqual(5);

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -35,6 +35,7 @@ describe('context', function() {
 describe('webdriverJS Jasmine adapter', function() {
   // Shorten this and you should see tests timing out.
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 2000;
+  var beforeEachMsg;
 
   beforeEach(function() {
     jasmine.addMatchers(common.getMatchers());
@@ -42,8 +43,12 @@ describe('webdriverJS Jasmine adapter', function() {
 
   beforeEach(function() {
     fakeDriver.setUp().then(function(value) {
-      // console.log('This should print before each test: ' + value);
+      beforeEachMsg = value;
     });
+  });
+
+  afterEach(function() {
+    beforeEachMsg = '';
   });
 
   it('should pass normal synchronous tests', function() {
@@ -53,6 +58,10 @@ describe('webdriverJS Jasmine adapter', function() {
   it('should compare a promise to a primitive', function() {
     expect(fakeDriver.getValueA()).toEqual('a');
     expect(fakeDriver.getValueB()).toEqual('b');
+  });
+
+  it('beforeEach should wait for control flow', function() {
+    expect(beforeEachMsg).toEqual('setup done');
   });
 
   it('should wait till the expect to run the flow', function() {
@@ -147,6 +156,35 @@ describe('webdriverJS Jasmine adapter', function() {
         x = 1;
         done();
       }, 500);
+    });
+  });
+
+  describe('beforeAll and afterAll', function() {
+    var asyncValue, setupMsg;
+
+    beforeAll(function(done) {
+      setTimeout(function() {
+        asyncValue = 5;
+        done();
+      }, 500);
+    });
+
+    beforeAll(function() {
+      fakeDriver.setUp().then(function(msg) {
+        setupMsg = msg;
+      });
+    });
+
+    afterAll(function() {
+      setupMsg = '';
+    });
+
+    it('should have set asyncValue', function() {
+      expect(asyncValue).toEqual(5);
+    });
+
+    it('should wait for control flow', function() {
+      expect(setupMsg).toEqual('setup done');
     });
   });
 });

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -14,6 +14,12 @@ describe('webdriverJS Jasmine adapter plain', function() {
   it('should pass normal synchronous tests', function() {
     expect(true).toBe(true);
   });
+
+  it('should allow an empty it block and mark as pending');
+
+  xit('should allow a spec marked as pending with xit', function() {
+    expect(true).toBe(false);
+  });
 });
 
 describe('context', function() {

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -221,4 +221,16 @@ describe('webdriverJS Jasmine adapter', function() {
       expect(setupMsg).toEqual('setup done');
     });
   });
+
+  describe('it return value', function() {
+    var spec1 = it('test1');
+    var spec2 = it('test2', function() {});
+    var spec3 = it('test3', function() {}, 1);
+
+    it('should return the spec', function() {
+      expect(spec1.description).toBe('test1');
+      expect(spec2.description).toBe('test2');
+      expect(spec3.description).toBe('test3');
+    });
+  });
 });

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -155,6 +155,11 @@ describe('webdriverJS Jasmine adapter', function() {
     it('should compare a promise to a promise', function() {
       expect(fakeDriver.getValueA()).not.toEqual(fakeDriver.getValueB());
     });
+
+    it('should allow custom matchers to return a promise when actual is not a promise', function() {
+      expect(fakeDriver.displayedElement).toBeDisplayed();
+      expect(fakeDriver.hiddenElement).not.toBeDisplayed();
+    });
   });
 
   it('should throw an error with a WebElement actual value', function() {

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -1,5 +1,6 @@
-require('../index.js');
 var webdriver = require('selenium-webdriver');
+var common = require('./common.js');
+require('../index.js');
 
 /**
  * Tests for the WebDriverJS Jasmine-Node Adapter. These tests use
@@ -7,69 +8,7 @@ var webdriver = require('selenium-webdriver');
  * webdriver.
  */
 
-var getFakeDriver = function() {
-  var flow = webdriver.promise.controlFlow();
-  return {
-    controlFlow: function() {
-      return flow;
-    },
-    sleep: function(ms) {
-      return flow.timeout(ms);
-    },
-    setUp: function() {
-      return flow.execute(function() {
-        return webdriver.promise.fulfilled('setup done');
-      });
-    },
-    getValueA: function() {
-      return flow.execute(function() {
-        return webdriver.promise.delayed(500).then(function() {
-          return webdriver.promise.fulfilled('a');
-        });
-      });
-    },
-    getOtherValueA: function() {
-      return flow.execute(function() {
-        return webdriver.promise.fulfilled('a');
-      });
-    },
-    getValueB: function() {
-      return flow.execute(function() {
-        return webdriver.promise.fulfilled('b');
-      });
-    },
-    getBigNumber: function() {
-      return flow.execute(function() {
-        return webdriver.promise.fulfilled(1111);
-      });
-    },
-    getDecimalNumber: function() {
-        return flow.execute(function() {
-          return webdriver.promise.fulfilled(3.14159);
-        });
-      },
-    getDisplayedElement: function() {
-      return flow.execute(function() {
-        return webdriver.promise.fulfilled({
-          isDisplayed: function() {
-            return webdriver.promise.fulfilled(true);
-          }
-        });
-      });
-    },
-    getHiddenElement: function() {
-      return flow.execute(function() {
-        return webdriver.promise.fulfilled({
-          isDisplayed: function() {
-            return webdriver.promise.fulfilled(false);
-          }
-        });
-      });
-    }
-  };
-};
-
-var fakeDriver = getFakeDriver();
+var fakeDriver = common.getFakeDriver();
 
 describe('webdriverJS Jasmine adapter plain', function() {
   it('should pass normal synchronous tests', function() {
@@ -80,24 +19,15 @@ describe('webdriverJS Jasmine adapter plain', function() {
 
 describe('webdriverJS Jasmine adapter', function() {
   // Shorten this and you should see tests timing out.
-  jasmine.getEnv().defaultTimeoutInterval = 2000;
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 2000;
 
   beforeEach(function() {
-    // 'this' should work properly to add matchers.
-    this.addMatchers({
-      toBeLotsMoreThan: function(expected) {
-        return this.actual > expected + 100;
-      },
-      // Example custom matcher returning a promise that resolves to true/false.
-      toBeDisplayed: function() {
-        return this.actual.isDisplayed();
-      }
-    });
+    jasmine.addMatchers(common.getMatchers());
   });
 
   beforeEach(function() {
     fakeDriver.setUp().then(function(value) {
-      console.log('This should print before each test: ' + value);
+      // console.log('This should print before each test: ' + value);
     });
   });
 
@@ -136,6 +66,8 @@ describe('webdriverJS Jasmine adapter', function() {
   it('should allow the use of custom matchers', function() {
     expect(500).toBeLotsMoreThan(3);
     expect(fakeDriver.getBigNumber()).toBeLotsMoreThan(33);
+    expect(fakeDriver.getBigNumber()).toBeLotsMoreThan(fakeDriver.getSmallNumber());
+    expect(fakeDriver.getSmallNumber()).not.toBeLotsMoreThan(fakeDriver.getBigNumber());
   });
 
   it('should allow custom matchers to return a promise', function() {
@@ -175,21 +107,6 @@ describe('webdriverJS Jasmine adapter', function() {
     }).toThrow('expect called with WebElement argument, expected a Promise. ' +
         'Did you mean to use .getText()?');
   });
-
-  // Uncomment to see timeout failures.
-
-  // it('should timeout after 200ms', function() {
-  //   expect(fakeDriver.getValueA()).toEqual('a');
-  // }, 300);
-
-  // it('should timeout after 300ms', function() {
-  //   fakeDriver.sleep(9999);
-  //   expect(fakeDriver.getValueB()).toEqual('b');
-  // }, 300);
-
-  // it('should pass errors from done callback', function(done) {
-  //   done('an error');
-  // });
 
   it('should pass after the timed out tests', function() {
     expect(fakeDriver.getValueA()).toEqual('a');

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -16,6 +16,21 @@ describe('webdriverJS Jasmine adapter plain', function() {
   });
 });
 
+describe('context', function() {
+  beforeEach(function() {
+    this.foo = 0;
+  });
+
+  it('can use the `this` to share state', function() {
+    expect(this.foo).toEqual(0);
+    this.bar = 'test pollution?';
+  });
+
+  it('prevents test pollution by having an empty `this` created for the next spec', function() {
+    expect(this.foo).toEqual(0);
+    expect(this.bar).toBe(undefined);
+  });
+});
 
 describe('webdriverJS Jasmine adapter', function() {
   // Shorten this and you should see tests timing out.

--- a/spec/common.js
+++ b/spec/common.js
@@ -1,0 +1,93 @@
+require('../index.js');
+var webdriver = require('selenium-webdriver');
+
+exports.getFakeDriver = function() {
+  var flow = webdriver.promise.controlFlow();
+  return {
+    controlFlow: function() {
+      return flow;
+    },
+    sleep: function(ms) {
+      return flow.timeout(ms);
+    },
+    setUp: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled('setup done');
+      });
+    },
+    getValueA: function() {
+      return flow.execute(function() {
+        return webdriver.promise.delayed(500).then(function() {
+          return webdriver.promise.fulfilled('a');
+        });
+      });
+    },
+    getOtherValueA: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled('a');
+      });
+    },
+    getValueB: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled('b');
+      });
+    },
+    getBigNumber: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled(1111);
+      });
+    },
+    getSmallNumber: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled(11);
+      });
+    },
+    getDecimalNumber: function() {
+        return flow.execute(function() {
+          return webdriver.promise.fulfilled(3.14159);
+        });
+      },
+    getDisplayedElement: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled({
+          isDisplayed: function() {
+            return webdriver.promise.fulfilled(true);
+          }
+        });
+      });
+    },
+    getHiddenElement: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled({
+          isDisplayed: function() {
+            return webdriver.promise.fulfilled(false);
+          }
+        });
+      });
+    }
+  };
+};
+
+exports.getMatchers = function() {
+  return {
+    toBeLotsMoreThan: function() {
+      return {
+        compare: function(actual, expected) {
+          return {
+            pass: actual > expected + 100
+          };
+        }
+      };
+    },
+    // Example custom matcher returning a promise that resolves to true/false.
+    toBeDisplayed: function() {
+      return {
+        compare: function(actual, expected) {
+          return {
+            pass: actual.isDisplayed()
+          };
+        }
+      };
+    }
+  };
+};

--- a/spec/common.js
+++ b/spec/common.js
@@ -64,6 +64,27 @@ exports.getFakeDriver = function() {
           }
         });
       }, 'getHiddenElement');
+    },
+    getValueList: function() {
+      return flow.execute(function() {
+        return webdriver.promise.fulfilled([{
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('a');});
+          }
+        }, {
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('b');});
+          }
+        }, {
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('c');});
+          }
+        }, {
+          getText: function() {
+            return flow.execute(function() { return webdriver.promise.fulfilled('d');});
+          }
+        }]);
+      }, 'getValueList');
     }
   };
 };

--- a/spec/common.js
+++ b/spec/common.js
@@ -13,39 +13,39 @@ exports.getFakeDriver = function() {
     setUp: function() {
       return flow.execute(function() {
         return webdriver.promise.fulfilled('setup done');
-      });
+      }, 'setUp');
     },
     getValueA: function() {
       return flow.execute(function() {
         return webdriver.promise.delayed(500).then(function() {
           return webdriver.promise.fulfilled('a');
         });
-      });
+      }, 'getValueA');
     },
     getOtherValueA: function() {
       return flow.execute(function() {
         return webdriver.promise.fulfilled('a');
-      });
+      }, 'getOtherValueA');
     },
     getValueB: function() {
       return flow.execute(function() {
         return webdriver.promise.fulfilled('b');
-      });
+      }, 'getValueB');
     },
     getBigNumber: function() {
       return flow.execute(function() {
         return webdriver.promise.fulfilled(1111);
-      });
+      }, 'getBigNumber');
     },
     getSmallNumber: function() {
       return flow.execute(function() {
         return webdriver.promise.fulfilled(11);
-      });
+      }, 'getSmallNumber');
     },
     getDecimalNumber: function() {
         return flow.execute(function() {
           return webdriver.promise.fulfilled(3.14159);
-        });
+        }, 'getDecimalNumber');
       },
     getDisplayedElement: function() {
       return flow.execute(function() {
@@ -54,7 +54,7 @@ exports.getFakeDriver = function() {
             return webdriver.promise.fulfilled(true);
           }
         });
-      });
+      }, 'getDisplayedElement');
     },
     getHiddenElement: function() {
       return flow.execute(function() {
@@ -63,7 +63,7 @@ exports.getFakeDriver = function() {
             return webdriver.promise.fulfilled(false);
           }
         });
-      });
+      }, 'getHiddenElement');
     }
   };
 };

--- a/spec/common.js
+++ b/spec/common.js
@@ -85,6 +85,16 @@ exports.getFakeDriver = function() {
           }
         }]);
       }, 'getValueList');
+    },
+    displayedElement: {
+      isDisplayed: function() {
+        return webdriver.promise.fulfilled(true);
+      }
+    },
+    hiddenElement: {
+      isDisplayed: function() {
+        return webdriver.promise.fulfilled(false);
+      }
     }
   };
 };

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -31,7 +31,7 @@ describe('things that should fail', function() {
   });
 
   it('should pass errors from done callback', function(done) {
-    done.fail('an error');
+    done.fail('an error from done.fail');
   });
 
   it('should fail normal synchronous tests', function() {

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -38,6 +38,10 @@ describe('things that should fail', function() {
     expect(true).toBe(false);
   });
 
+  it('should fail when an error is thrown', function() {
+    throw new Error('I am an intentional error');
+  });
+
   it('should compare a promise to a primitive', function() {
     expect(fakeDriver.getValueA()).toEqual('d');
     expect(fakeDriver.getValueB()).toEqual('e');

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -34,9 +34,15 @@ describe('things that should fail', function() {
     done.fail('an error from done.fail');
   });
 
+  it('should error asynchronously in promise callbacks', function() {
+    fakeDriver.sleep(50).then(function() {
+      expect(true).toEqual(false);
+    });
+  });
+
   it('should error asynchronously within done callback', function(done) {
     setTimeout(function() {
-      expect(false).toBeTruthy();
+      expect(false).toEqual(true);
       done();
     }, 200);
   });

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -1,0 +1,89 @@
+var webdriver = require('selenium-webdriver');
+var common = require('./common.js');
+require('../index.js');
+
+/**
+ * Error tests for the WebDriverJS Jasmine-Node Adapter. These tests use
+ * WebDriverJS's control flow and promises without setting up the whole
+ * webdriver.
+ */
+
+var fakeDriver = common.getFakeDriver();
+
+describe('Timeout cases', function() {
+  it('should timeout after 200ms', function(done) {
+    expect(fakeDriver.getValueA()).toEqual('a');
+  }, 200);
+  
+  it('should timeout after 300ms', function() {
+    fakeDriver.sleep(9999);
+    expect(fakeDriver.getValueB()).toEqual('b');
+  }, 300);
+
+  it('should pass after the timed out tests', function() {
+    expect(true).toEqual(true);
+  });
+});
+
+describe('things that should fail', function() {
+  beforeEach(function() {
+    jasmine.addMatchers(common.getMatchers());
+  });
+
+  it('should pass errors from done callback', function(done) {
+    done.fail('an error');
+  });
+
+  it('should fail normal synchronous tests', function() {
+    expect(true).toBe(false);
+  });
+
+  it('should compare a promise to a primitive', function() {
+    expect(fakeDriver.getValueA()).toEqual('d');
+    expect(fakeDriver.getValueB()).toEqual('e');
+  });
+
+  it('should wait till the expect to run the flow', function() {
+    var promiseA = fakeDriver.getValueA();
+    expect(promiseA.isPending()).toBe(true);
+    expect(promiseA).toEqual('a');
+    expect(promiseA.isPending()).toBe(false);
+  });
+
+  it('should compare a promise to a promise', function() {
+    expect(fakeDriver.getValueA()).toEqual(fakeDriver.getValueB());
+  });
+
+  it('should still allow use of the underlying promise', function() {
+    var promiseA = fakeDriver.getValueA();
+    promiseA.then(function(value) {
+      expect(value).toEqual('b');
+    });
+  });
+
+  it('should allow scheduling of tasks', function() {
+    fakeDriver.sleep(300);
+    expect(fakeDriver.getValueB()).toEqual('c');
+  });
+
+  it('should allow the use of custom matchers', function() {
+    expect(1000).toBeLotsMoreThan(999);
+    expect(fakeDriver.getBigNumber()).toBeLotsMoreThan(1110);
+    expect(fakeDriver.getBigNumber()).not.toBeLotsMoreThan(fakeDriver.getSmallNumber());
+    expect(fakeDriver.getSmallNumber()).toBeLotsMoreThan(fakeDriver.getBigNumber());
+  });
+
+  it('should allow custom matchers to return a promise', function() {
+    expect(fakeDriver.getDisplayedElement()).not.toBeDisplayed();
+    expect(fakeDriver.getHiddenElement()).toBeDisplayed();
+  });
+
+  it('should pass multiple arguments to matcher', function() {
+    // Passing specific precision
+    expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.5, 1);
+
+    // Using default precision (2)
+    expect(fakeDriver.getDecimalNumber()).toBeCloseTo(3.1);
+    expect(fakeDriver.getDecimalNumber()).not.toBeCloseTo(3.14);
+  });
+});

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -34,6 +34,13 @@ describe('things that should fail', function() {
     done.fail('an error from done.fail');
   });
 
+  it('should error asynchronously within done callback', function(done) {
+    setTimeout(function() {
+      expect(false).toBeTruthy();
+      done();
+    }, 200);
+  });
+
   it('should fail normal synchronous tests', function() {
     expect(true).toBe(false);
   });

--- a/spec/support/failing_specs.json
+++ b/spec/support/failing_specs.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "errorSpec.js"
+  ]
+}

--- a/spec/support/passing_specs.json
+++ b/spec/support/passing_specs.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "adapterSpec.js"
+  ]
+}


### PR DESCRIPTION
When the library versions differ at runtime you get strange test behaviour where the jasmine wrappers do not evaluate the control flow correctly.
More details here: https://github.com/angular/protractor/issues/2790