### PR TITLE
Pin the selenium-webdriver version so that it correctly matches protractor.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "jasmine"
   ],
   "author": "Julie Ralph <ju.ralph@gmail.com>",
+  "dependencies": {
+    "selenium-webdriver": "2.48.2"
+  },
   "devDependencies": {
     "jshint": "2.5.0",
-    "jasmine": "2.4.1",
-    "selenium-webdriver": "2.48.2"
+    "jasmine": "2.4.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
My team experienced problems running protractor with symptoms as described in https://github.com/angular/protractor/issues/2790.  We were able to trace it down to a situation where a bad combination of dependencies (angular, protractor, and benchpress) introduced multiple copies of selenium webdriver into the node_modules tree.  This then caused jasminewd2 to resolve the wrong version of selenium webdriver, fail to actually execute anything, and silently return success for all our protractor test cases.

The problem is described in more detail in angular/protractor#2790.

This is the simplest and safest fix I could come up with.  Maybe there is another way to achieve the same thing?