### PR TITLE
Support unwrapping promises when actual is primitive and expected val…

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,8 +169,18 @@ jasmine.Expectation.prototype.wrapCompare = function(name, matcherFactory) {
 
     matchError.stack = matchError.stack.replace(/ +at.+jasminewd.+\n/, '');
 
+
+    function areAnyExpectedValuesPromises(expected){
+      for (var i = 0; i < expected.length; i++) {
+        if(webdriver.promise.isPromise(expected[i])){
+          return true;
+        }
+      }
+      return false;
+    }
+
     if (!webdriver.promise.isPromise(expectation.actual) &&
-        !webdriver.promise.isPromise(expected)) {
+        !areAnyExpectedValuesPromises(expected)) {
       compare(expectation.actual, expected);
     } else {
       webdriver.promise.when(expectation.actual).then(function(actual) {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ $CMD
 [ "$?" -eq 0 ] || exit 1
 echo
 
-EXPECTED_RESULTS="16 specs, 15 failures"
+EXPECTED_RESULTS="17 specs, 16 failures"
 echo "### running failing specs (expecting $EXPECTED_RESULTS)"
 CMD=$CMD_BASE$FAILING_SPECS
 echo "### $CMD"

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -66,6 +66,11 @@ describe('webdriverJS Jasmine adapter', function() {
     expect(fakeDriver.getValueB()).toEqual('b');
   });
 
+  it('should compare a primitive to a promise', function() {
+    expect('a').toEqual(fakeDriver.getValueA());
+    expect('b').toEqual(fakeDriver.getValueB());
+  });
+
   it('beforeEach should wait for control flow', function() {
     expect(beforeEachMsg).toEqual('setup done');
   });

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -60,6 +60,11 @@ describe('things that should fail', function() {
     expect(fakeDriver.getValueB()).toEqual('e');
   });
 
+  it('should compare a primitive to a promise', function() {
+    expect('e').toEqual(fakeDriver.getValueA());
+    expect('f').toEqual(fakeDriver.getValueB());
+  });
+
   it('should wait till the expect to run the flow', function() {
     var promiseA = fakeDriver.getValueA();
     expect(promiseA.isPending()).toBe(true);


### PR DESCRIPTION
…ue is a promise (#47)

This commit adds support for 

`expect(<primitive>).toEqual(<promise>)`
