### PR TITLE
fix(webdriver): Pass in the control flow.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,12 +140,12 @@ function wrapInControlFlow(flow, globalFn, fnName) {
 }
 
 /**
- * Initialize the Jasminewd adapter with a particlar webdriver instance. We
+ * Initialize the JasmineWd adapter with a particlar webdriver instance. We
  * pass webdriver here instead of using require() in order to ensure Protractor
  * and Jasminews are using the same webdriver instance.
  * @param {Object} flow. The ControlFlow to wrap tests in.
  */
-function initJasminewd(flow) {
+function initJasmineWd(flow) {
   global.it = wrapInControlFlow(flow, global.it, 'it');
   global.fit = wrapInControlFlow(flow, global.fit, 'fit');
   global.beforeEach = wrapInControlFlow(flow, global.beforeEach, 'beforeEach');
@@ -284,4 +284,4 @@ OnTimeoutReporter.prototype.specDone = function(result) {
   }
 };
 
-module.exports.init = initJasminewd;
+module.exports.init = initJasmineWd;

--- a/index.js
+++ b/index.js
@@ -146,6 +146,11 @@ function wrapInControlFlow(flow, globalFn, fnName) {
  * @param {Object} flow. The ControlFlow to wrap tests in.
  */
 function initJasmineWd(flow) {
+  if (jasmine.JasmineWdInitialized) {
+    throw Error('JasmineWd already initialized when init() was called');
+  }
+  jasmine.JasmineWdInitialized = true;
+
   global.it = wrapInControlFlow(flow, global.it, 'it');
   global.fit = wrapInControlFlow(flow, global.fit, 'fit');
   global.beforeEach = wrapInControlFlow(flow, global.beforeEach, 'beforeEach');

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -1,6 +1,5 @@
 var webdriver = require('selenium-webdriver');
 var common = require('./common.js');
-require('../index.js');
 
 /**
  * Tests for the WebDriverJS Jasmine-Node Adapter. These tests use
@@ -167,8 +166,8 @@ describe('webdriverJS Jasmine adapter', function() {
 
     expect(function() {
       expect(webElement).toEqual(4);
-    }).toThrow('expect called with WebElement argument, expected a Promise. ' +
-        'Did you mean to use .getText()?');
+    }).toThrow(Error('expect called with WebElement argument, expected a Promise. ' +
+        'Did you mean to use .getText()?'));
   });
 
   it('should pass after the timed out tests', function() {

--- a/spec/adapterSpec.js
+++ b/spec/adapterSpec.js
@@ -56,6 +56,11 @@ describe('webdriverJS Jasmine adapter', function() {
     beforeEachMsg = '';
   });
 
+  it('should only allow initializing once', function() {
+    expect(require('../index.js').init).toThrow(
+      Error('JasmineWd already initialized when init() was called'));
+  });
+
   it('should pass normal synchronous tests', function() {
     expect(true).toEqual(true);
   });

--- a/spec/common.js
+++ b/spec/common.js
@@ -1,8 +1,9 @@
-require('../index.js');
 var webdriver = require('selenium-webdriver');
 
+var flow = webdriver.promise.controlFlow();
+require('../index.js').init(flow);
+
 exports.getFakeDriver = function() {
-  var flow = webdriver.promise.controlFlow();
   return {
     controlFlow: function() {
       return flow;

--- a/spec/errorSpec.js
+++ b/spec/errorSpec.js
@@ -1,6 +1,5 @@
 var webdriver = require('selenium-webdriver');
 var common = require('./common.js');
-require('../index.js');
 
 /**
  * Error tests for the WebDriverJS Jasmine-Node Adapter. These tests use


### PR DESCRIPTION
Fixes [angular/protractor #3505](https://github.com/angular/protractor/issues/3505), which was caused by Protractor and Jasminewd finding different webdriver instances through require(), and
thus using different ControlFlows.