### PR TITLE
feat(SELENIUM_PROMISE_MANAGER): Don't rely on `webdriver.promise` fun…

### DIFF
--- a/maybePromise.js
+++ b/maybePromise.js
@@ -8,6 +8,18 @@
  * or may not be promises, and code execution may or may not be synchronous.
  */
 
+
+/**
+ * Determines if a value is a promise.
+ *
+ * @param {*} val The value to check.
+ * @return {boolean} true if val is a promise, false otherwise.
+ */
+function isPromise(val) {
+  return val && (typeof val.then == 'function');
+}
+
+
 /**
  * Runs a callback synchronously against non-promise values and asynchronously
  * against promises.  Similar to ES6's `Promise.resolve` except that it is
@@ -25,12 +37,14 @@
  *   resolving to the callback's return value is returned.
  */
 var maybePromise = module.exports = function maybePromise(val, callback) {
-  if (val && (typeof val.then == 'function')) {
+  if (isPromise(val)) {
     return val.then(callback);
   } else {
     return callback(val);
   }
 }
+
+maybePromise.isPromise = isPromise;
 
 /**
  * Like maybePromise() but for an array of values.  Analogous to `Promise.all`.

--- a/scheduler.md
+++ b/scheduler.md
@@ -1,0 +1,68 @@
+# Schedulers
+
+Many of the core features of jasminewd are centered around automatically synchronizing your tests
+with the WebDriver control flow.  However, jasminewd can synchronize with any scheduler as long as
+it implements the following interface:
+
+```ts
+interface Scheduler {
+  execute<T>(fn: () => Promise<T>|T): Promise<T>;
+}
+```
+
+Where `execute` is the function used to put something on the scheduler.  As long as your scheduler
+implements this interface, you can pass it into `require('jasminewd2').init`.
+
+## Custom Promise Implementation
+
+Some schedulers need scheduled functions to use a specific implementation of the promise API.  For
+instance, WebDriver has its `ManagedPromise` implementation, which it needs in order to track
+tasks across `then()` blocks.  If your scheduler has its own promise implementation, you can
+implement the following interface:
+
+```ts
+interface SchedulerWithCustomPromises {
+  execute<T>(fn: () => CustomPromise<T>|T): CustomPromise<T>;
+  promise<T>(resolver: (resolve: (T) => void, reject: (any) => void) => void): CustomPromise<T>;
+}
+```
+
+If the `promise` function is specified, jasminewd will use that function to generate all of its
+internal promises.  If `scheduler.promise` is not specified, jasminewd will try to use WebDriver's
+`ManagedPromise`.  If `ManagedPromise` is not available (e.g. the control flow is disabled),
+jasminewd will default to using native promises.
+
+### Idle API
+
+If your scheduler requires a custom promise implementation, it is highly recommended that you
+implement the Idle API.  This will help to mitigate issues with users who sometimes use other
+promise implementations (see https://github.com/angular/jasminewd/issues/68#issuecomment-262317167). 
+To do this, implement the following interface: 
+
+```ts
+var EventEmitter = require('events');
+
+interface SchedulerWithIdleAPI extends EventEmitter {
+  execute<T>(fn: () => CustomPromise<T>|T): CustomPromise<T>;
+  promise<T>(resolver: (resolve: (T) => void, reject: (any) => void) => void): CustomPromise<T>;
+  isIdle(): boolean;
+}
+```
+
+Your scheduler must emit `"idle"` when it becomes idle.
+
+
+### Reset API
+
+If you want your scheduler to be reset whenever a spec times out, implement the following interface:
+
+```ts
+interface SchedulerWithResetAPI {
+  execute<T>(fn: () => CustomPromise<T>|T): CustomPromise<T>;
+  reset(): void;
+}
+```
+
+jasminewd will automatically look for a `reset` function and call it when specs time out.  This is
+useful so that tasks from a timed out spec get cleared instead of continuing to tie up the scheduler
+and potentially getting executed during future specs.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,7 +39,27 @@ echo "result: $results_line"
 
 export SELENIUM_PROMISE_MANAGER=0
 
-echo "### running async/await passing specs"
+echo "### running async/await passing specs with control flow disabled"
+CMD=$CMD_BASE$NO_CF_PASSING_SPECS
+echo "### $CMD"
+$CMD
+[ "$?" -eq 0 ] || exit 1
+echo
+
+EXPECTED_RESULTS="19 specs, 17 failures"
+echo "### running async/await failing specs (expecting $EXPECTED_RESULTS)"
+CMD=$CMD_BASE$NO_CF_FAILING_SPECS
+echo "### $CMD"
+res=`$CMD 2>/dev/null`
+results_line=`echo "$res" | tail -2 | head -1`
+echo "result: $results_line"
+[ "$results_line" = "$EXPECTED_RESULTS" ] || exit 1
+
+# Run only the async/await tests with no scheduler
+
+export JASMINEWD_TESTS_NO_SCHEDULER=1
+
+echo "### running async/await passing specs with no scheduler"
 CMD=$CMD_BASE$NO_CF_PASSING_SPECS
 echo "### $CMD"
 $CMD

--- a/spec/common.ts
+++ b/spec/common.ts
@@ -1,7 +1,7 @@
 import {promise as wdpromise, WebElement} from 'selenium-webdriver';
 
 const flow = wdpromise.controlFlow();
-require('../index.js').init(flow);
+require('../index.js').init(process.env['JASMINEWD_TESTS_NO_SCHEDULER'] ? null : flow);
 
 export function getFakeDriver() {
   return {

--- a/spec/maybePromiseSpec.js
+++ b/spec/maybePromiseSpec.js
@@ -13,6 +13,17 @@ describe('maybePromise', function() {
     return promise;
   }
 
+  it('should be able to tell promises from non-promises', function() {
+    expect(maybePromise.isPromise(num)).toBe(false);
+    expect(maybePromise.isPromise(str)).toBe(false);
+    expect(maybePromise.isPromise(obj)).toBe(false);
+    expect(maybePromise.isPromise(idFun)).toBe(false);
+    expect(maybePromise.isPromise(promiseMe(num))).toBe(true);
+    expect(maybePromise.isPromise(promiseMe(str))).toBe(true);
+    expect(maybePromise.isPromise(promiseMe(obj))).toBe(true);
+    expect(maybePromise.isPromise(promiseMe(idFun))).toBe(true);
+  });
+
   describe('singletons', function() {
     it('should be able to use non-promises', function(done) {
       maybePromise(num, function(n) {


### PR DESCRIPTION
…ctions

While we support `SELENIUM_PROMISE_MANAGER=0` already, we rely on `SimpleScheduler` and some other
utility functions which will be going away.  This allows jasminewd to work without those utility
functions, and even allows people to pass jasminewd their own custom scheduler implementation.

This does not fix our tests, which will also break when those utility functions go away.  See
https://github.com/angular/jasminewd/issues/81

Closes https://github.com/angular/jasminewd/issues/80