### PR TITLE
feat(init): ***breaking change*** pass webdriver instance into `init()`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,24 +28,27 @@ npm install jasminewd2
 Usage
 -----
 
-Assumes selenium-webdriver as a peer dependency.
+In your setup:
 
 ```js
-// In your setup.
 var JasmineRunner = require('jasmine');
 var jrunner = new JasmineRunner();
-require('jasminewd2');
+var webdriver = require('selenium-webdriver');
 
 global.driver = new webdriver.Builder().
     usingServer('http://localhost:4444/wd/hub').
     withCapabilities({browserName: 'chrome'}).
     build();
 
+require('jasminewd2').init(driver.controlFlow(), webdriver);
+
 jrunner.projectBaseDir = '';
 jrunner.execute(['**/*_spec.js']);
+```
 
-// In your tests
+In your tests:
 
+```js
 describe('tests with webdriver', function() {
   it('will wait until webdriver is done', function() {
     // This will be an asynchronous test. It will finish once webdriver has
@@ -76,7 +79,7 @@ publish typings for this function.  If you call this function directly (e.g. you
 are a Protractor dev), you should simply do:
 
 ```ts
-require('jasminewd2').init(controlFlow);
+require('jasminewd2').init(controlFlow, webdriver);
 ```
 
 `async` functions / `await`

--- a/package.json
+++ b/package.json
@@ -11,17 +11,13 @@
     "jasmine"
   ],
   "author": "Julie Ralph <ju.ralph@gmail.com>",
-  "dependencies": {
-    "jasmine": "2.4.1",
-    "selenium-webdriver": "3.0.1"
-  },
   "devDependencies": {
     "@types/jasmine": "^2.5.40",
     "@types/node": "^6.0.56",
     "@types/selenium-webdriver": "^2.53.38",
     "jasmine": "2.4.1",
     "jshint": "^2.9.4",
-    "selenium-webdriver": "2.53.3",
+    "selenium-webdriver": "3.0.1",
     "tslint": "^4.2.0",
     "tslint-eslint-rules": "^3.2.3",
     "typescript": "^2.0.10",

--- a/spec/common.ts
+++ b/spec/common.ts
@@ -1,7 +1,8 @@
 import {promise as wdpromise, WebElement} from 'selenium-webdriver';
 
 const flow = wdpromise.controlFlow();
-require('../index.js').init(process.env['JASMINEWD_TESTS_NO_SCHEDULER'] ? null : flow);
+require('../index.js').init(process.env['JASMINEWD_TESTS_NO_SCHEDULER'] ? null : flow,
+    require('selenium-webdriver'));
 
 export function getFakeDriver() {
   return {


### PR DESCRIPTION
… instead of using `require()`

This removes the dependency on `selenium-webdriver` and protects jasminewd from having a different
webdriver instance than Protractor, which could be a huge problem if they had different control flow
settings.

This is a breaking change because it changes the API for the `init` function.