### PR TITLE
minor fix to keep stack from original error

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,8 +94,10 @@ function wrapInScheduler(scheduler, newPromise, globalFn, fnName) {
         scheduler.execute(function schedulerExecute() {
           return newPromise(function(fulfill, reject) {
             function wrappedReject(err) {
-              var wrappedErr = new Error(err);
-              reject(wrappedErr);
+              if(err instanceof Error)
+                reject(err);
+              else 
+                reject(new Error(err));
             }
             if (async) {
               // If testFn is async (it expects a done callback), resolve the promise of this


### PR DESCRIPTION
If rejection has an error this is swallowed by wrappedReject. This small fix should resolve this problem reporting original stack trace and allowing faster debugging.