### PR TITLE
Support native async functions (node 7.6+)

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var maybePromise = require('./maybePromise');
  * @return {Object} The original parameter.
  */
 function validateFunction(functionToValidate) {
-  if (functionToValidate && Object.prototype.toString.call(functionToValidate) === '[object Function]') {
+  if (functionToValidate && typeof functionToValidate === 'function') {
     return functionToValidate;
   } else {
     throw Error(functionToValidate + ' is not a function');


### PR DESCRIPTION
Long story short:
```
~
λ node --version
v7.7.1
~
λ node
> Object.prototype.toString.call(async function(){})
'[object AsyncFunction]'
```